### PR TITLE
Coveralls config

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+coverage_clover: clover.xml
+json_path: coveralls-upload.json

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 /docs export-ignore
 /test export-ignore
+/.coveralls.yml export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
     </testsuites>
 
     <filter>
-        <whitelist>
+        <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>


### PR DESCRIPTION
Added missing `.coveralls.yml` and added attribute to process uncovered files from whitelist in PHPUnit configuration.

**Please enable coverall for the repository**
It seems to be disabled, as the badge in `README.md` shows unknown coverage right now.