### PR TITLE
CS fixes

### DIFF
--- a/src/ZendRbac.php
+++ b/src/ZendRbac.php
@@ -40,7 +40,7 @@ class ZendRbac implements AuthorizationInterface
     /**
      * {@inheritDoc}
      */
-    public function isGranted(string $role, ServerRequestInterface $request): bool
+    public function isGranted(string $role, ServerRequestInterface $request) : bool
     {
         $routeResult = $request->getAttribute(RouteResult::class, false);
         if (false === $routeResult) {

--- a/src/ZendRbacAssertionInterface.php
+++ b/src/ZendRbacAssertionInterface.php
@@ -8,7 +8,7 @@
 namespace Zend\Expressive\Authorization\Rbac;
 
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\Permissions\Rbac\AssertionInterface as AssertionInterface;
+use Zend\Permissions\Rbac\AssertionInterface;
 
 interface ZendRbacAssertionInterface extends AssertionInterface
 {

--- a/src/ZendRbacAssertionInterface.php
+++ b/src/ZendRbacAssertionInterface.php
@@ -12,5 +12,5 @@ use Zend\Permissions\Rbac\AssertionInterface as AssertionInterface;
 
 interface ZendRbacAssertionInterface extends AssertionInterface
 {
-    public function setRequest(ServerRequestInterface $request): void;
+    public function setRequest(ServerRequestInterface $request) : void;
 }

--- a/src/ZendRbacFactory.php
+++ b/src/ZendRbacFactory.php
@@ -9,7 +9,6 @@ namespace Zend\Expressive\Authorization\Rbac;
 
 use Psr\Container\ContainerInterface;
 use Zend\Expressive\Authorization\AuthorizationInterface;
-use Zend\Permissions\Rbac\AssertionInterface;
 use Zend\Permissions\Rbac\Exception\ExceptionInterface as RbacExceptionInterface;
 use Zend\Permissions\Rbac\Rbac;
 


### PR DESCRIPTION
- space before colon of return type declaration
- removed redundant alias on import
- removed unused imports