### PR TITLE
Allow usage of 1.0.0-dev branch of zend-expressive-authorization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "php": "^7.1",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-authorization": "^0.1 || ^0.2 || ^0.3 || ^1.0",
-        "zendframework/zend-expressive-router": "^2.1",
+        "zendframework/zend-expressive-authorization": "^0.1 || ^0.2 || ^0.3 || ^1.0.0-dev || ^1.0",
+        "zendframework/zend-expressive-router": "^2.1 || ^3.0.0-dev || ^3.0",
         "zendframework/zend-permissions-rbac": "^2.5.1"
     },
     "require-dev": {
@@ -50,7 +50,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.0.x-dev"
         },
         "zf": {
             "config-provider": "Zend\\Expressive\\Authorization\\Rbac\\ConfigProvider"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc72291b1d2a88d8e59d9ce21d504074",
+    "content-hash": "82ae749d1a7d45da1779d9dccf0e625e",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -2240,6 +2240,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "zendframework/zend-expressive-authorization": 20,
+        "zendframework/zend-expressive-router": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,


### PR DESCRIPTION
The 1.0.0-dev branch of zend-expressive-authorization prepares for incorporation of PSR-15 interfaces; however, the API it exposes for adapters does not change.

Also requires allowing zend-expressive-router 3.0 series (including dev releases).